### PR TITLE
fix: Change basic auth token for monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -46,10 +46,12 @@ sites:
   - name: Monitoring platform
     url: "https://alertmanager.openfoodfacts.org/#/alerts"
     headers:
-      - "Authorization: Basic $ALERT_MANAGER_BASICAUTH"
+      - "Authorization: Basic $MONITORING_BASICAUTH"
 
   - name: Prometheus
     url: "https://prometheus.openfoodfacts.org/-/healthy"
+    headers:
+      - "Authorization: Basic $MONITORING_BASICAUTH"
 
   - name: Search
     url: https://search.openfoodfacts.org/?q=Nutella


### PR DESCRIPTION
# Current Issue

As we can see on https://status.openfoodfacts.org prometheus and alertmanager seem down. This is because we recently added a new password on those websites, and upptime doesn't have access.

# Changes

- This PR adds those passwords to the requests made by upptime.
- I also changed the secret name to use the same naming scheme as in monitoring and infrastructure.

# TODO after merge

When we will have checked that everything works, delete `ALERT_MANAGER_BASICAUTH` secret.


